### PR TITLE
Explain how to use linkTo and generateFilePath to call an API

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -8,6 +8,8 @@ declare global {
 
 /**
  * Get an url with webroot to a file in an app
+ * Note: to call an API declared in an app's appinfo/routes.php, use
+ *       linkTo(appName, 'index.php') + '/path/to/your/api'
  *
  * @param {string} app the id of the app the file belongs to
  * @param {string} file the file path relative to the app folder
@@ -136,6 +138,8 @@ export const imagePath = (app: string, file: string) => {
 
 /**
  * Get the url with webroot for a file in an app
+ * Note: to call an API declared in an app's appinfo/routes.php, use
+ *       generateFilePath(appName, '', 'index.php') + '/path/to/your/api'
  *
  * @param {string} app the id of the app
  * @param {string} type the type of the file to link to (e.g. css,img,ajax.template)


### PR DESCRIPTION
I spent a bit of time to understand why `linkTo` and `generateFilePath` would return `/custom_apps/{appName}/path/to/api` instead of `/apps/{appName}/path/to/api` on a Nextcloud instance running in Docker when used like this:

    linkTo(appName, action)

This call worked on my Nextcloud instances because I don't use docker (to the app was installed in `apps/`) and the reverse proxy is set up such as `index.php` is not needed. The correct usage for API calls, as found in the code of other apps,  is:

    linkTo(appName, 'index.php') + '/' + action

There's a special case for files ending with ".php" in `generateFilePath`. I understand that `generateFilePath` is designed to link to static resources at `/apps` or `/custom_files` depending on where the app is installed, *unless the file is a php file*.

I'm not sure I documented this correctly, but to save other's people confusion, this should be pointed out. We might actually want to mention the `.php` special case and explain what I'm explaining somewhere, but I was not sure how to do it so feel free to edit my PR before merging. 

Signed-off-by: raphj <raphael.jakse@xwiki.com>