### PR TITLE
fix(deps): Make @nextcloud/typings a regular dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.1.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
+        "@nextcloud/typings": "^1.0.0",
         "core-js": "^3.6.4"
       },
       "devDependencies": {
@@ -17,7 +18,6 @@
         "@babel/preset-env": "^7.9.0",
         "@babel/preset-typescript": "^7.9.0",
         "@nextcloud/browserslist-config": "^2.0.0",
-        "@nextcloud/typings": "^1.0.0",
         "typedoc": "^0.24.1",
         "typescript": "^4.0.2"
       },
@@ -2088,7 +2088,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.6.0.tgz",
       "integrity": "sha512-5uIsteFy9Z9/ZaNGE8w8SDgJp+FK8/LeRLgfnakC2pU8eNKTPlQfkiYR163oEI5Xu5YzwdIzf6/roIXdNinhrw==",
-      "dev": true,
       "dependencies": {
         "@types/jquery": "2.0.60"
       },
@@ -2107,8 +2106,7 @@
     "node_modules/@types/jquery": {
       "version": "2.0.60",
       "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.60.tgz",
-      "integrity": "sha512-izi6OBEVrAwaHiqWITjOPBbVtcKZKAXTocJqPZsAKA2lvmbpFEyPSAxgcqmisbiMYj9EvrooUEPLHQeQqVMWAg==",
-      "dev": true
+      "integrity": "sha512-izi6OBEVrAwaHiqWITjOPBbVtcKZKAXTocJqPZsAKA2lvmbpFEyPSAxgcqmisbiMYj9EvrooUEPLHQeQqVMWAg=="
     },
     "node_modules/ansi-sequence-parser": {
       "version": "1.1.0",
@@ -4610,7 +4608,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.6.0.tgz",
       "integrity": "sha512-5uIsteFy9Z9/ZaNGE8w8SDgJp+FK8/LeRLgfnakC2pU8eNKTPlQfkiYR163oEI5Xu5YzwdIzf6/roIXdNinhrw==",
-      "dev": true,
       "requires": {
         "@types/jquery": "2.0.60"
       }
@@ -4625,8 +4622,7 @@
     "@types/jquery": {
       "version": "2.0.60",
       "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.60.tgz",
-      "integrity": "sha512-izi6OBEVrAwaHiqWITjOPBbVtcKZKAXTocJqPZsAKA2lvmbpFEyPSAxgcqmisbiMYj9EvrooUEPLHQeQqVMWAg==",
-      "dev": true
+      "integrity": "sha512-izi6OBEVrAwaHiqWITjOPBbVtcKZKAXTocJqPZsAKA2lvmbpFEyPSAxgcqmisbiMYj9EvrooUEPLHQeQqVMWAg=="
     },
     "ansi-sequence-parser": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "url": "https://github.com/nextcloud/nextcloud-router"
   },
   "dependencies": {
-    "core-js": "^3.6.4"
+    "core-js": "^3.6.4",
+    "@nextcloud/typings": "^1.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",
@@ -30,7 +31,6 @@
     "@babel/preset-env": "^7.9.0",
     "@babel/preset-typescript": "^7.9.0",
     "@nextcloud/browserslist-config": "^2.0.0",
-    "@nextcloud/typings": "^1.0.0",
     "typedoc": "^0.24.1",
     "typescript": "^4.0.2"
   },


### PR DESCRIPTION
This ensures that dependents of `@nextcloud/router` get the typings.

This follows the suggestions of https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#dependencies.