### PR TITLE
fix: Do not export the declaration of `window.OC`

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,11 +1,3 @@
-/// <reference types="@nextcloud/typings" />
-
-declare global {
-    interface Window {
-        OC: Nextcloud.v16.OC | Nextcloud.v17.OC | Nextcloud.v18.OC | Nextcloud.v19.OC | Nextcloud.v20.OC;
-    }
-}
-
 /**
  * Get an url with webroot to a file in an app
  *

--- a/lib/oc.d.ts
+++ b/lib/oc.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="@nextcloud/typings" />
+
+declare interface Window {
+    OC: Nextcloud.v23.OC | Nextcloud.v24.OC | Nextcloud.v25.OC;
+}


### PR DESCRIPTION
Currently the distribution files contain the declaration of the `window.OC` variable which is then bound to that specific value.
This will lead to error for apps written in typescript if they want to declare it differently (e.g. only support NC25).

With this PR the declaration will not be included, as it is not necessary for the typings of this library. And additionally the typings are updated.