### PR TITLE
chore: Prepare v2.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.1.2 – 2023-06-13
+
+[Full Changelog](https://github.com/nextcloud/nextcloud-router/compare/v2.1.1...v2.1.2)
+
+### Fixed
+- Do not export the declaration of `window.OC` to prevent typing clashes with applications
+
 ## 2.1.1 – 2023-04-21
 
 [Full Changelog](https://github.com/nextcloud/nextcloud-router/compare/v2.1.0...v2.1.1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/router",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/router",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/typings": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/router",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Patch release to allow using different `window.OC` typing in apps.